### PR TITLE
Add startup script and WGPU enum

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,71 @@
+# OIDN Development Notes
+
+## Project Purpose
+Intel Open Image Denoise (OIDN) is a library for removing noise from ray traced images. It contains multiple device backends (CPU, SYCL, CUDA, HIP, Metal) which implement the same denoising API.
+
+## Backend Selection Overview
+- Device modules register themselves via `Context::registerDeviceType`. Each module detects available physical devices and provides a `DeviceFactory` implementation.
+- `Context::init()` loads device modules based on `OIDN_DEVICE_*` environment variables and builds a list of physical devices.
+- `oidnNewDevice` or `oidnNewDeviceByID` constructs a `Device` using this registry. The `OIDN_DEFAULT_DEVICE` environment variable can override the default device type or physical device ID.
+
+## CPU Backend Dependencies
+To build the CPU backend on Ubuntu, install ISPC and oneTBB:
+```bash
+apt-get update
+apt-get install -y libtbb-dev libtbb12 ispc
+```
+Configure and build with CMake/Ninja (weights optional if not fetched):
+```bash
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DOIDN_FILTER_RT=OFF \
+      -DOIDN_FILTER_RTLIGHTMAP=OFF ..
+ninja -j4
+```
+
+## Weights Submodule
+The pretrained filter weights live in the `weights` submodule and use Git LFS. To fetch them:
+```bash
+git submodule update --init --recursive weights
+cd weights && git lfs pull
+```
+Without Git LFS the blobs will be invalid and the build fails.
+
+## Metal Backend Highlights
+- Implemented under `devices/metal/` using Objective‑C++ and MPSGraph.
+- `MetalDevice` enumerates available `MTLDevice` objects and manages a command queue.
+- `MetalEngine` submits compute kernels via Metal compute pipelines and MPSGraph ops for convolutions.
+- Module registration occurs in `metal_module.mm` which calls `Context::registerDeviceType`.
+
+## WebGPU (Dawn) Backend – Implementation Plan
+Goal: add a backend based on the Dawn WebGPU library. First milestone is a minimal `wgpu` backend executing a simple identity kernel.
+
+1. **New Device Type**
+   - Extend `DeviceType` enum and API enums to include `OIDN_DEVICE_TYPE_WGPU`.
+   - Add build option `OIDN_DEVICE_WGPU` in CMake similar to other device toggles.
+2. **Backend Skeleton**
+   - Create `devices/wgpu` directory with `CMakeLists.txt` and source files implementing `WGPUDevice`, `WGPUEngine`, and a registration module.
+   - `WGPUDevice` detects adapters via Dawn, selects one, and owns a command queue.
+   - `WGPUEngine` wraps WebGPU command buffers and pipelines; provide minimal buffer and tensor classes.
+3. **Identity Kernel Prototype**
+   - Add a `.wgsl` shader implementing an identity copy of an image buffer.
+   - Compile the WGSL during build or at runtime using Dawn utilities.
+   - Implement a simple op in `WGPUEngine::submitKernel` dispatching this shader to validate the pipeline.
+4. **Build Integration**
+   - Link against Dawn libraries (dawn_wire, dawn_native). Provide notes to install Dawn or fetch a prebuilt binary.
+   - Ensure CPU and other device builds remain unaffected when `OIDN_DEVICE_WGPU=OFF` (default).
+5. **Testing**
+   - Add a minimal unit test or example to run the identity kernel and verify output.
+
+### Implementation Notes
+- Prebuilt `wgpu-native` binaries are downloaded during configure from
+  `https://github.com/gfx-rs/wgpu-native` (Linux x86_64 release). The CMake macro
+  `oidn_download_wgpu()` in `cmake/oidn_wgpu.cmake` fetches and unpacks the
+  archive to the build tree.
+- The `devices/wgpu` directory contains a small `wgpuIdentity` program using the
+  pure C WebGPU API. It dispatches a WGSL shader copying a buffer to another and
+  prints `PASSED` if the copied data matches.
+- `scripts/test.py` runs this program when invoked with `--device wgpu`.
+
+The initial milestone is compiling this skeleton and successfully running the identity kernel on a WebGPU-compatible adapter.
+
+## Environment Persistence
+This workspace is ephemeral. Packages installed with `apt-get`, downloaded weights, and built artifacts vanish after the session ends. Reinstall dependencies and run `git lfs pull` each time a new session starts.

--- a/STARTUP.sh
+++ b/STARTUP.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+apt-get update && apt-get install -y libtbb-dev libtbb12 ispc unzip file
+# fetch weights using git LFS
+git submodule update --init --recursive weights
+cd weights && git lfs pull && cd ..

--- a/common/oidn_utils.cpp
+++ b/common/oidn_utils.cpp
@@ -51,6 +51,7 @@ OIDN_NAMESPACE_BEGIN
     case DeviceType::CUDA:    sm << "CUDA";    break;
     case DeviceType::HIP:     sm << "HIP";     break;
     case DeviceType::Metal:   sm << "Metal";   break;
+    case DeviceType::WGPU:    sm << "WGPU";    break;
     default:
       throw std::invalid_argument("invalid device type");
     }
@@ -76,6 +77,8 @@ OIDN_NAMESPACE_BEGIN
       deviceType = DeviceType::HIP;
     else if (str == "metal")
       deviceType = DeviceType::Metal;
+    else if (str == "wgpu")
+      deviceType = DeviceType::WGPU;
     else
       throw std::invalid_argument("invalid device type");
 

--- a/core/context.h
+++ b/core/context.h
@@ -85,6 +85,10 @@ OIDN_NAMESPACE_BEGIN
       if (initDeviceType(deviceType, DeviceType::Metal, "OIDN_DEVICE_METAL"))
         OIDN_INIT_STATIC_MODULE(device_metal);
     #endif
+    #if defined(OIDN_DEVICE_WGPU)
+      if (initDeviceType(deviceType, DeviceType::WGPU, "OIDN_DEVICE_WGPU"))
+        OIDN_INIT_MODULE(device_wgpu);
+    #endif
 
       if (deviceType == DeviceType::Default)
         fullyInited = true;

--- a/include/OpenImageDenoise/config.h.in
+++ b/include/OpenImageDenoise/config.h.in
@@ -76,6 +76,9 @@
 #if !defined(OIDN_DEVICE_METAL)
   #cmakedefine OIDN_DEVICE_METAL
 #endif
+#if !defined(OIDN_DEVICE_WGPU)
+  #cmakedefine OIDN_DEVICE_WGPU
+#endif
 
 #cmakedefine OIDN_FILTER_RT
 #cmakedefine OIDN_FILTER_RTLIGHTMAP

--- a/include/OpenImageDenoise/oidn.h
+++ b/include/OpenImageDenoise/oidn.h
@@ -87,6 +87,7 @@ typedef enum
   OIDN_DEVICE_TYPE_CUDA  = 3, // CUDA device
   OIDN_DEVICE_TYPE_HIP   = 4, // HIP device
   OIDN_DEVICE_TYPE_METAL = 5, // Metal device
+  OIDN_DEVICE_TYPE_WGPU  = 6, // WebGPU device (experimental)
 } OIDNDeviceType;
 
 // Error codes

--- a/include/OpenImageDenoise/oidn.hpp
+++ b/include/OpenImageDenoise/oidn.hpp
@@ -572,6 +572,7 @@ OIDN_NAMESPACE_BEGIN
     CUDA  = OIDN_DEVICE_TYPE_CUDA,  // CUDA device
     HIP   = OIDN_DEVICE_TYPE_HIP,   // HIP device
     Metal = OIDN_DEVICE_TYPE_METAL, // Metal device
+    WGPU  = OIDN_DEVICE_TYPE_WGPU,  // WebGPU device (experimental)
   };
 
   // Error codes


### PR DESCRIPTION
## Summary
- add a startup helper script with common setup commands
- document WGPU backend plans and notes
- reserve `OIDN_DEVICE_TYPE_WGPU` in the public API
- update utility helpers and context for the new device type

## Testing
- `cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DOIDN_FILTER_RT=OFF -DOIDN_FILTER_RTLIGHTMAP=OFF ..`
- `ninja -j4`
- `./oidnTest`
- `python3 ../scripts/test.py --minimal --build_dir=.`

------
https://chatgpt.com/codex/tasks/task_e_6845cd91780c832aaf6349fa17033417