### PR TITLE
Fix WebGPU compilation and enable tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ End Goal: add the new backend based on the WebGPU API.
 ## Configure: enable WebGPU backend (OFF by default)
 cmake -B build -G Ninja \
       -DCMAKE_BUILD_TYPE=Release \
-      -DOIDN_DEVICE_WEBGPU=ON .
+      -DOIDN_DEVICE_WEBGPU=ON \
+      -DOIDN_FILTER_RT=OFF -DOIDN_FILTER_RTLIGHTMAP=OFF .
 
 ## Build everything
 cmake --build build -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ add_subdirectory(common)
 add_subdirectory(core)
 add_subdirectory(api)
 add_subdirectory(devices)
+enable_testing()
 add_subdirectory(tests)
 
 # Export targets from the build tree for external projects

--- a/devices/webgpu/webgpu_engine.h
+++ b/devices/webgpu/webgpu_engine.h
@@ -16,6 +16,18 @@ OIDN_NAMESPACE_BEGIN
 
     Device* getDevice() const override;
 
+    // Engine interface overrides - currently unsupported operations
+    Ref<Conv> newConv(const ConvDesc& desc) override;
+    Ref<Pool> newPool(const PoolDesc& desc) override;
+    Ref<Upsample> newUpsample(const UpsampleDesc& desc) override;
+    Ref<Autoexposure> newAutoexposure(const ImageDesc& srcDesc) override;
+    Ref<InputProcess> newInputProcess(const InputProcessDesc& desc) override;
+    Ref<OutputProcess> newOutputProcess(const OutputProcessDesc& desc) override;
+    Ref<ImageCopy> newImageCopy() override;
+    void submitHostFunc(std::function<void()>&& f,
+                        const Ref<CancellationToken>& ct = nullptr) override;
+    void wait() override;
+
     WebGPUTensor newTensor(const float* data, WebGPUTensorType type,
                            uint32_t n, uint32_t c, uint32_t h, uint32_t w);
 

--- a/devices/webgpu/webgpu_helper.cpp
+++ b/devices/webgpu/webgpu_helper.cpp
@@ -3,11 +3,12 @@
 
 OIDN_NAMESPACE_BEGIN
 
-  WebGPUEngine* getEngine(DeviceRef device)
+  __attribute__((visibility("default"))) __attribute__((used)) WebGPUEngine* getEngine(DeviceRef device)
   {
     if (!device)
       return nullptr;
-    return static_cast<WebGPUEngine*>(device->getEngine());
+    Device* impl = reinterpret_cast<Device*>(device.getHandle());
+    return static_cast<WebGPUEngine*>(impl->getEngine());
   }
 
 OIDN_NAMESPACE_END

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,9 @@
 find_package(GTest REQUIRED)
-add_executable(webgpu_conv_test test_webgpu_conv.cpp)
+add_executable(webgpu_conv_test test_webgpu_conv.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_helper.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_engine.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_device.cpp)
 target_include_directories(webgpu_conv_test PRIVATE ${PROJECT_SOURCE_DIR}/devices/webgpu)
 target_include_directories(webgpu_conv_test PRIVATE ${PROJECT_SOURCE_DIR})
-target_link_libraries(webgpu_conv_test PRIVATE OpenImageDenoise GTest::GTest GTest::Main)
+target_link_libraries(webgpu_conv_test PRIVATE OpenImageDenoise OpenImageDenoise_core GTest::GTest GTest::Main)
 add_test(NAME WebGPU.Conv2d COMMAND webgpu_conv_test)


### PR DESCRIPTION
## Summary
- implement stub methods in `WebGPUEngine` and update WebGPU API usage
- fix adapter/device creation and buffer mapping for latest WebGPU
- export a helper function and inline wrappers for testing
- enable CTest and link helper sources to the WebGPU test
- document build options for missing weights

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DOIDN_DEVICE_WEBGPU=ON -DOIDN_FILTER_RT=OFF -DOIDN_FILTER_RTLIGHTMAP=OFF .`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure -R WebGPU.Conv2d`

------
https://chatgpt.com/codex/tasks/task_e_684741daba38832aa7e85537083f074c