### PR TITLE
Align WebGPU conv test with CPU backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,10 @@ Run: ctest --output-on-failure -R WebGPU
 
 The tests internally:
 
-prepare deterministic random tensors,
-run the same operation on CPU and WebGPU,
-and declare success if
+prepares deterministic random tensors,
+executes the convolution using the CPU backend to get the reference output,
+runs the same layer on the WebGPU backend,
+declares success if
 max( |ref - gpu| / max(|ref|, 1e-6) ) < 1e-4.
 
 ## Next Steps / Perspective

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,8 +4,9 @@ add_executable(webgpu_conv_test test_webgpu_conv.cpp
   ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_engine.cpp
   ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_device.cpp)
 target_include_directories(webgpu_conv_test PRIVATE ${PROJECT_SOURCE_DIR}/devices/webgpu)
+target_include_directories(webgpu_conv_test PRIVATE ${PROJECT_SOURCE_DIR}/devices/cpu)
 target_include_directories(webgpu_conv_test PRIVATE ${PROJECT_SOURCE_DIR})
-target_link_libraries(webgpu_conv_test PRIVATE OpenImageDenoise OpenImageDenoise_core GTest::GTest GTest::Main)
+target_link_libraries(webgpu_conv_test PRIVATE OpenImageDenoise OpenImageDenoise_core OpenImageDenoise_device_cpu GTest::GTest GTest::Main)
 add_test(NAME WebGPU.Conv2d COMMAND webgpu_conv_test)
 
 add_executable(webgpu_upsample_test test_webgpu_upsample.cpp

--- a/tests/test_webgpu_conv.cpp
+++ b/tests/test_webgpu_conv.cpp
@@ -1,5 +1,11 @@
 #include "OpenImageDenoise/webgpu.h"
 #include "../devices/webgpu/webgpu_engine.h"
+#include "../devices/cpu/cpu_device.h"
+#include "../devices/cpu/cpu_engine.h"
+#include "../devices/cpu/cpu_conv.h"
+#include "../core/tensor.h"
+#include "../core/tensor_reorder.h"
+#include "../common/platform.h"
 #include <gtest/gtest.h>
 
 using namespace oidn;
@@ -24,17 +30,86 @@ TEST(WebGPU, Conv2d)
   uint32_t OH=H-KH+1; uint32_t OW=W-KW+1;
   float out[OC*OH*OW];
   float ref[OC*OH*OW];
-  for(uint32_t y=0;y<OH;++y)
-    for(uint32_t x=0;x<OW;++x)
+
+  // --- reference using CPU backend ---
+  if (isCPUDeviceSupported())
+  {
+    auto cpuDev = newDevice(DeviceType::CPU);
+    cpuDev.commit();
+    auto cpuImpl = static_cast<CPUDevice*>(reinterpret_cast<Device*>(cpuDev.getHandle()));
+    CPUEngine* cpuEng = static_cast<CPUEngine*>(cpuImpl->getEngine());
+    const int blockC = cpuImpl->getTensorBlockC();
+
+    TensorDesc srcDesc({int(C),int(H),int(W)},
+                       {round_up(int(C),blockC),int(H),int(W)},
+                       cpuImpl->getTensorLayout(), DataType::Float32);
+    auto srcTensor = makeRef<HostTensor>(srcDesc);
+
+    auto packChw = [&](float* dst)
     {
-      float acc=0.f;
-      for(uint32_t ky=0;ky<KH;++ky)
-        for(uint32_t kx=0;kx<KW;++kx)
-          acc+=src[(y+ky)*W+(x+kx)]*weight[ky*KW+kx];
-      acc+=bias[0];
-      if(acc<0.f) acc=0.f;
-      ref[y*OW+x]=acc;
-    }
+      for(int c=0;c<round_up(int(C),blockC);++c)
+        for(int h=0;h<int(H);++h)
+          for(int w=0;w<int(W);++w)
+          {
+            size_t idx=((size_t)(c/blockC)*H + h)*(W*blockC)+w*blockC+(c%blockC);
+            if(c<int(C))
+              dst[idx]=src[(size_t)c*H*W+h*W+w];
+            else
+              dst[idx]=0.f;
+          }
+    };
+    packChw(static_cast<float*>(srcTensor->getPtr()));
+
+    TensorDesc wSrcDesc({int(OC),int(IC),int(KH),int(KW)}, TensorLayout::oihw, DataType::Float32);
+    auto wSrcTensor = makeRef<HostTensor>(wSrcDesc, weight);
+    TensorDesc wDesc({int(OC),int(IC),int(KH),int(KW)},
+                     {round_up(int(OC),blockC),round_up(int(IC),blockC),int(KH),int(KW)},
+                     cpuImpl->getWeightLayout(), DataType::Float32);
+    auto wTensor = makeRef<HostTensor>(wDesc);
+    reorderWeight(*wSrcTensor, *wTensor);
+
+    TensorDesc bSrcDesc({int(OC)}, TensorLayout::x, DataType::Float32);
+    auto bSrcTensor = makeRef<HostTensor>(bSrcDesc, bias);
+    TensorDesc bDesc({int(OC)}, {round_up(int(OC),blockC)}, TensorLayout::x, DataType::Float32);
+    auto bTensor = makeRef<HostTensor>(bDesc);
+    reorderBias(*bSrcTensor, *bTensor);
+
+    auto conv = cpuEng->newConv({srcDesc, wDesc, bDesc, Activation::ReLU, PostOp::None, false});
+    conv->setSrc(srcTensor);
+    conv->setWeight(wTensor);
+    conv->setBias(bTensor);
+    auto dstDesc = conv->getDstDesc();
+    auto dstTensor = makeRef<HostTensor>(dstDesc);
+    conv->setDst(dstTensor);
+    conv->submit(nullptr);
+    cpuDev.sync();
+
+    auto unpackChw = [&](const float* srcPacked)
+    {
+      for(int c=0;c<int(OC);++c)
+        for(int h=0;h<int(OH);++h)
+          for(int w=0;w<int(OW);++w)
+          {
+            size_t idx=((size_t)(c/blockC)*OH + h)*(OW*blockC)+w*blockC+(c%blockC);
+            ref[(size_t)c*OH*OW+h*OW+w]=srcPacked[idx];
+          }
+    };
+    unpackChw(static_cast<float*>(dstTensor->getPtr()));
+  }
+  else
+  {
+    for(uint32_t y=0;y<OH;++y)
+      for(uint32_t x=0;x<OW;++x)
+      {
+        float acc=0.f;
+        for(uint32_t ky=0;ky<KH;++ky)
+          for(uint32_t kx=0;kx<KW;++kx)
+            acc+=src[(y+ky)*W+(x+kx)]*weight[ky*KW+kx];
+        acc+=bias[0];
+        if(acc<0.f) acc=0.f;
+        ref[y*OW+x]=acc;
+      }
+  }
 
   auto A = eng->newTensor(src, WebGPUTensorType::INPUT, N,C,H,W);
   auto Wt= eng->newTensor(weight, WebGPUTensorType::CONST, OC,IC,KH,KW);


### PR DESCRIPTION
## Summary
- use CPU backend as the reference implementation
- expose CPU headers for the test and link against CPU device library
- update verification notes in `AGENTS.md`

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DOIDN_DEVICE_WEBGPU=ON -DOIDN_FILTER_RT=OFF -DOIDN_FILTER_RTLIGHTMAP=OFF .`
- `cmake --build build -j$(nproc)`
- `cd build && ctest --output-on-failure -R WebGPU.Conv2d`

------
https://chatgpt.com/codex/tasks/task_e_6847e6d1fdec832ab6c2c6b07228d30b