### PR TITLE
Align WebGPU layout with Metal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,10 @@ Host ↔ GPU transfers use the public buffer API (`oidnNewBuffer`, `oidnWriteBuf
 Currently three kernels are hooked up: `conv2d_eltwise`, `pool2x2`, and `upsample2x`.
 Op classes WebGPUConv/WebGPUPool/WebGPUUpsample expose these through the standard Engine API and are validated against the CPU backend.
 
+The Metal backend serves as the reference implementation.  It uses NHWC tensor
+layout with OIHW weights.  The WebGPU backend now adopts the same layouts and
+the tests still compare its results against the CPU backend for convenience.
+
 ## Verification Procedure
 Build with -DOIDN_DEVICE_WEBGPU=ON.
 

--- a/devices/webgpu/webgpu_device.cpp
+++ b/devices/webgpu/webgpu_device.cpp
@@ -63,6 +63,13 @@ OIDN_NAMESPACE_BEGIN
 
     queue = wgpuDeviceGetQueue(device);
 
+    // Use the same native tensor layouts as the Metal backend (NHWC / OIHW)
+    tensorDataType = DataType::Float32;
+    weightDataType = DataType::Float32;
+    tensorLayout   = TensorLayout::hwc;
+    weightLayout   = TensorLayout::oihw;
+    tensorBlockC   = 1;
+
     subdevices.emplace_back(new Subdevice(std::unique_ptr<Engine>(new WebGPUEngine(this))));
   }
 

--- a/devices/webgpu/webgpu_engine.cpp
+++ b/devices/webgpu/webgpu_engine.cpp
@@ -35,7 +35,7 @@ OIDN_NAMESPACE_BEGIN
         for (var kx: u32 = 0u; kx < size.kw; kx = kx + 1u) {
           let ix = ox + kx;
           let iy = oy + ky;
-          let srcIdx = (((0u * size.ic + ic) * size.ih + iy) * size.iw + ix);
+          let srcIdx = (((0u * size.ih + iy) * size.iw + ix) * size.ic + ic);
           let wIdx   = (((oc * size.ic + ic) * size.kh + ky) * size.kw + kx);
           acc = acc + src.data[srcIdx] * weight.data[wIdx];
         }
@@ -43,7 +43,7 @@ OIDN_NAMESPACE_BEGIN
     }
     acc = acc + bias.data[oc];
     if (acc < 0.0) { acc = 0.0; }
-    let dstIdx = (((0u * size.oc + oc) * size.oh + oy) * size.ow + ox);
+    let dstIdx = (((0u * size.oh + oy) * size.ow + ox) * size.oc + oc);
     dst.data[dstIdx] = acc;
   }
   )wgsl";
@@ -64,15 +64,16 @@ OIDN_NAMESPACE_BEGIN
     if (ox >= size.ow || oy >= size.oh || c >= size.c) { return; }
     let ix = ox * 2u;
     let iy = oy * 2u;
-    let srcIdx0 = (((0u * size.c + c) * size.h + iy) * size.w + ix);
-    let srcIdx1 = srcIdx0 + 1u;
-    let srcIdx2 = srcIdx0 + size.w;
-    let srcIdx3 = srcIdx2 + 1u;
+    let base = (((0u * size.h + iy) * size.w + ix) * size.c + c);
+    let srcIdx0 = base;
+    let srcIdx1 = base + size.c;
+    let srcIdx2 = base + size.c * size.w;
+    let srcIdx3 = srcIdx2 + size.c;
     var m = src.data[srcIdx0];
     if (src.data[srcIdx1] > m) { m = src.data[srcIdx1]; }
     if (src.data[srcIdx2] > m) { m = src.data[srcIdx2]; }
     if (src.data[srcIdx3] > m) { m = src.data[srcIdx3]; }
-    let dstIdx = (((0u * size.c + c) * size.oh + oy) * size.ow + ox);
+    let dstIdx = (((0u * size.oh + oy) * size.ow + ox) * size.c + c);
     dst.data[dstIdx] = m;
   }
   )wgsl";
@@ -93,8 +94,8 @@ OIDN_NAMESPACE_BEGIN
     if (ox >= size.w*2u || oy >= size.h*2u || c >= size.c) { return; }
     let ix = ox / 2u;
     let iy = oy / 2u;
-    let srcIdx = (((0u * size.c + c) * size.h + iy) * size.w + ix);
-    let dstIdx = (((0u * size.c + c) * (size.h*2u) + oy) * (size.w*2u) + ox);
+    let srcIdx = (((0u * size.h + iy) * size.w + ix) * size.c + c);
+    let dstIdx = (((0u * (size.h*2u) + oy) * (size.w*2u) + ox) * size.c + c);
     dst.data[dstIdx] = src.data[srcIdx];
   }
   )wgsl";

--- a/tests/test_webgpu_upsample.cpp
+++ b/tests/test_webgpu_upsample.cpp
@@ -81,11 +81,17 @@ TEST(WebGPU, Upsample2x)
         ref[y*OW+x] = src[(y/2)*W + (x/2)];
   }
 
-  auto srcBuf = dev.newBuffer(sizeof(src));
-  srcBuf.write(0, sizeof(src), src);
+  float srcGPU[N*C*H*W];
+  for(uint32_t h=0; h<H; ++h)
+    for(uint32_t w=0; w<W; ++w)
+      for(uint32_t c=0; c<C; ++c)
+        srcGPU[(h*W + w)*C + c] = src[(size_t)c*H*W + h*W + w];
+
+  auto srcBuf = dev.newBuffer(sizeof(srcGPU));
+  srcBuf.write(0, sizeof(srcGPU), srcGPU);
   auto outBuf = dev.newBuffer(sizeof(out));
 
-  TensorDesc srcDescGPU({int(C),int(H),int(W)}, TensorLayout::chw, DataType::Float32);
+  TensorDesc srcDescGPU({int(C),int(H),int(W)}, TensorLayout::hwc, DataType::Float32);
   auto srcTensorGPU = eng->Engine::newTensor(Ref<Buffer>(reinterpret_cast<Buffer*>(srcBuf.getHandle())), srcDescGPU);
 
   auto up = eng->newUpsample({srcDescGPU});
@@ -97,7 +103,12 @@ TEST(WebGPU, Upsample2x)
   up->setDst(dstTensorGPU);
   up->submit(nullptr);
   dev.sync();
-  outBuf.read(0, sizeof(out), out);
+  float outGPU[C*OH*OW];
+  outBuf.read(0, sizeof(outGPU), outGPU);
+  for(uint32_t h=0; h<OH; ++h)
+    for(uint32_t w=0; w<OW; ++w)
+      for(uint32_t c=0; c<C; ++c)
+        out[(size_t)c*OH*OW + h*OW + w] = outGPU[(h*OW + w)*C + c];
 
   for(size_t i=0;i<C*OH*OW;++i)
     ASSERT_NEAR(out[i], ref[i], 1e-6f);


### PR DESCRIPTION
## Summary
- match WebGPU tensor layouts with Metal backend (NHWC/OIHW)
- update WGSL shaders and helpers for new layout
- adjust unit tests to handle NHWC ordering
- clarify Metal reference and layout choices in AGENTS notes

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DOIDN_DEVICE_WEBGPU=ON -DOIDN_FILTER_RT=OFF -DOIDN_FILTER_RTLIGHTMAP=OFF .`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure -R WebGPU`

------
https://chatgpt.com/codex/tasks/task_e_6848229b9544832abb2500fa4de07dfc