### PR TITLE
Add WGSL element-wise ops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Fixed stride = 1, no padding, arbitrary N,C,H,W.
 Work-group size hard-coded to 8×8×1.
 Host ↔ GPU transfers use the public buffer API (`oidnNewBuffer`, `oidnWriteBuffer`,
 `oidnReadBuffer`).
-Currently kernels for `conv2d_eltwise`, `pool2x2`, `upsample2x`, `input_process`, `output_process`, `image_copy`, and `autoexposure` are implemented in WGSL shaders.
+Currently kernels for `conv2d_eltwise`, `pool2x2`, `upsample2x`, `add`, `mul`, `softplus`, `input_process`, `output_process`, `image_copy`, and `autoexposure` are implemented in WGSL shaders.
 Earlier revisions executed the last four operations on the CPU, but they now run on the GPU as well.
 Op classes map these kernels through the standard Engine API and are validated against the CPU backend.
 
@@ -102,7 +102,7 @@ They pass if
 ## Next Steps / Perspective
 
 Priority	Task	Brief Description
-P0	Element-wise kernels	Add remaining simple ops (add, mul, softplus, etc.) using inline WGSL.
+P0      Element-wise kernels    **Done** – WGSL implementations of add, mul, and softplus are available.
 P1	Memory allocator	Replace the “one buffer per tensor” strategy with a sub-allocator to reduce memory & improve performance.
 P1	Graph execution	Record multiple layers in a single command buffer to amortise overhead.
 P2	Full denoiser demo	Make examples/denoise run on a 256×256 tile using the WebGPU backend.

--- a/devices/webgpu/webgpu_engine.h
+++ b/devices/webgpu/webgpu_engine.h
@@ -52,12 +52,26 @@ OIDN_NAMESPACE_BEGIN
     void pool2x2(const WebGPUTensor& src,
                  const WebGPUTensor& dst);
 
+    void add(const WebGPUTensor& A,
+             const WebGPUTensor& B,
+             const WebGPUTensor& dst);
+
+    void mul(const WebGPUTensor& A,
+             const WebGPUTensor& B,
+             const WebGPUTensor& dst);
+
+    void softplus(const WebGPUTensor& src,
+                  const WebGPUTensor& dst);
+
     void sync();
 
   private:
     void initPipeline();
     void initUpsamplePipeline();
     void initPoolPipeline();
+    void initAddPipeline();
+    void initMulPipeline();
+    void initSoftplusPipeline();
 
     WebGPUDevice* device;
 
@@ -75,6 +89,21 @@ OIDN_NAMESPACE_BEGIN
     WGPUBindGroupLayout poolBindGroupLayout = nullptr;
     WGPUPipelineLayout poolPipelineLayout = nullptr;
     WGPUComputePipeline poolPipeline = nullptr;
+
+    WGPUShaderModule addShaderModule = nullptr;
+    WGPUBindGroupLayout addBindGroupLayout = nullptr;
+    WGPUPipelineLayout addPipelineLayout = nullptr;
+    WGPUComputePipeline addPipeline = nullptr;
+
+    WGPUShaderModule mulShaderModule = nullptr;
+    WGPUBindGroupLayout mulBindGroupLayout = nullptr;
+    WGPUPipelineLayout mulPipelineLayout = nullptr;
+    WGPUComputePipeline mulPipeline = nullptr;
+
+    WGPUShaderModule softplusShaderModule = nullptr;
+    WGPUBindGroupLayout softplusBindGroupLayout = nullptr;
+    WGPUPipelineLayout softplusPipelineLayout = nullptr;
+    WGPUComputePipeline softplusPipeline = nullptr;
 
     struct PendingReadback
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,3 +124,20 @@ target_include_directories(webgpu_autoexposure_test PRIVATE ${PROJECT_SOURCE_DIR
 target_include_directories(webgpu_autoexposure_test PRIVATE ${PROJECT_SOURCE_DIR})
 target_link_libraries(webgpu_autoexposure_test PRIVATE OpenImageDenoise OpenImageDenoise_core OpenImageDenoise_device_cpu GTest::GTest GTest::Main)
 add_test(NAME WebGPU.Autoexposure COMMAND webgpu_autoexposure_test)
+
+add_executable(webgpu_eltwise_test test_webgpu_eltwise.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_helper.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_engine.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_conv.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_pool.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_upsample.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_input_process.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_output_process.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_image_copy.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_autoexposure.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_buffer.cpp
+  ${PROJECT_SOURCE_DIR}/devices/webgpu/webgpu_device.cpp)
+target_include_directories(webgpu_eltwise_test PRIVATE ${PROJECT_SOURCE_DIR}/devices/webgpu)
+target_include_directories(webgpu_eltwise_test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(webgpu_eltwise_test PRIVATE OpenImageDenoise OpenImageDenoise_core GTest::GTest GTest::Main)
+add_test(NAME WebGPU.Eltwise COMMAND webgpu_eltwise_test)

--- a/tests/test_webgpu_eltwise.cpp
+++ b/tests/test_webgpu_eltwise.cpp
@@ -1,0 +1,113 @@
+#include "OpenImageDenoise/oidn.hpp"
+#include "OpenImageDenoise/webgpu.h"
+#include "../devices/webgpu/webgpu_engine.h"
+#include "../core/tensor.h"
+#include "../common/platform.h"
+#include <gtest/gtest.h>
+
+using namespace oidn;
+
+static void fillRandom(float* data, size_t count)
+{
+  for(size_t i=0;i<count;++i)
+    data[i] = float(i%13) * 0.1f + 0.3f; // deterministic
+}
+
+TEST(WebGPU, EltwiseAdd)
+{
+  if (!isWebGPUDeviceSupported())
+    GTEST_SKIP();
+  auto dev = newWebGPUDevice();
+  dev.commit();
+  WebGPUEngine* eng = getEngine(dev);
+
+  const uint32_t N=1,C=1,H=1,W=64; // 64 elements
+  constexpr size_t COUNT = N*C*H*W;
+  float a[COUNT];
+  float b[COUNT];
+  fillRandom(a, COUNT);
+  fillRandom(b, COUNT);
+  float ref[COUNT];
+  for(size_t i=0;i<COUNT;++i)
+    ref[i] = a[i] + b[i];
+
+  auto bufA = dev.newBuffer(sizeof(a));
+  bufA.write(0,sizeof(a),a);
+  auto bufB = dev.newBuffer(sizeof(b));
+  bufB.write(0,sizeof(b),b);
+  auto bufOut = dev.newBuffer(sizeof(ref));
+
+  auto tA = eng->newTensor(BufferRef(bufA.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tB = eng->newTensor(BufferRef(bufB.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tOut= eng->newTensor(BufferRef(bufOut.getHandle()), WebGPUTensorType::OUTPUT, 1,1,1,W);
+
+  eng->add(tA,tB,tOut);
+  dev.sync();
+  float out[COUNT];
+  bufOut.read(0,sizeof(out),out);
+  for(size_t i=0;i<COUNT;++i)
+    ASSERT_NEAR(out[i], ref[i], 1e-6f);
+}
+
+TEST(WebGPU, EltwiseMul)
+{
+  if (!isWebGPUDeviceSupported())
+    GTEST_SKIP();
+  auto dev = newWebGPUDevice();
+  dev.commit();
+  WebGPUEngine* eng = getEngine(dev);
+
+  const uint32_t N=1,C=1,H=1,W=64;
+  constexpr size_t COUNT = N*C*H*W;
+  float a[COUNT];
+  float b[COUNT];
+  fillRandom(a, COUNT);
+  fillRandom(b, COUNT);
+  float ref[COUNT];
+  for(size_t i=0;i<COUNT;++i)
+    ref[i]=a[i]*b[i];
+
+  auto bufA=dev.newBuffer(sizeof(a)); bufA.write(0,sizeof(a),a);
+  auto bufB=dev.newBuffer(sizeof(b)); bufB.write(0,sizeof(b),b);
+  auto bufOut=dev.newBuffer(sizeof(ref));
+  auto tA = eng->newTensor(BufferRef(bufA.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tB = eng->newTensor(BufferRef(bufB.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tOut= eng->newTensor(BufferRef(bufOut.getHandle()), WebGPUTensorType::OUTPUT, 1,1,1,W);
+
+  eng->mul(tA,tB,tOut);
+  dev.sync();
+  float out[COUNT];
+  bufOut.read(0,sizeof(out),out);
+  for(size_t i=0;i<COUNT;++i)
+    ASSERT_NEAR(out[i], ref[i], 1e-6f);
+}
+
+TEST(WebGPU, EltwiseSoftplus)
+{
+  if (!isWebGPUDeviceSupported())
+    GTEST_SKIP();
+  auto dev = newWebGPUDevice();
+  dev.commit();
+  WebGPUEngine* eng = getEngine(dev);
+
+  const uint32_t N=1,C=1,H=1,W=64;
+  constexpr size_t COUNT=N*C*H*W;
+  float a[COUNT];
+  fillRandom(a, COUNT);
+  float ref[COUNT];
+  for(size_t i=0;i<COUNT;++i)
+    ref[i] = logf(1.f + expf(a[i]));
+
+  auto bufA=dev.newBuffer(sizeof(a)); bufA.write(0,sizeof(a),a);
+  auto bufOut=dev.newBuffer(sizeof(ref));
+  auto tA = eng->newTensor(BufferRef(bufA.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tOut= eng->newTensor(BufferRef(bufOut.getHandle()), WebGPUTensorType::OUTPUT, 1,1,1,W);
+
+  eng->softplus(tA,tOut);
+  dev.sync();
+  float out[COUNT];
+  bufOut.read(0,sizeof(out),out);
+  for(size_t i=0;i<COUNT;++i)
+    ASSERT_NEAR(out[i], ref[i], 1e-6f);
+}
+


### PR DESCRIPTION
## Summary
- implement add/mul/softplus kernels in WebGPUEngine
- expose new APIs and initialize compute pipelines
- add WebGPU tests for element‑wise operations
- document completed WGSL kernels in AGENTS.md

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DOIDN_DEVICE_WEBGPU=ON -DOIDN_FILTER_RT=OFF -DOIDN_FILTER_RTLIGHTMAP=OFF .`
- `cmake --build build -j$(nproc)`
- `VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json ctest --output-on-failure -R WebGPU`

------
https://chatgpt.com/codex/tasks/task_e_6848386567ec832a8737eb7ac1898b00