### PR TITLE
Fix upsample test and add skip handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ Ensure environment selects a usable backend
 Hardware Vulkan/Metal or Lavapipe SW fallback.
 
 Run: ctest --output-on-failure -R WebGPU
+Skipped tests return exit code 77 which CTest recognizes as SKIP.
 
 The tests internally:
 

--- a/devices/webgpu/webgpu_engine.cpp
+++ b/devices/webgpu/webgpu_engine.cpp
@@ -15,7 +15,7 @@
 OIDN_NAMESPACE_BEGIN
 
   static const char* kConv2dWGSL = R"wgsl(
-  struct Tensor { data: array<f32>; };
+  struct Tensor { data: array<f32>, };
 
   @group(0) @binding(0) var<storage, read>  src   : Tensor;
   @group(0) @binding(1) var<storage, read>  weight: Tensor;
@@ -24,7 +24,7 @@ OIDN_NAMESPACE_BEGIN
 
   struct Size { n: u32, ic: u32, ih: u32, iw: u32,
                 oc: u32, oh: u32, ow: u32,
-                kh: u32, kw: u32 };
+                kh: u32, kw: u32, };
   @group(0) @binding(4) var<uniform> size: Size;
 
   @compute @workgroup_size(8, 8, 1)
@@ -54,11 +54,11 @@ OIDN_NAMESPACE_BEGIN
   )wgsl";
 
   static const char* kPoolWGSL = R"wgsl(
-  struct Tensor { data: array<f32>; };
+  struct Tensor { data: array<f32>, };
 
   @group(0) @binding(0) var<storage, read>  src : Tensor;
   @group(0) @binding(1) var<storage, read_write> dst : Tensor;
-  struct Size { n: u32, c: u32, h: u32, w: u32, oh: u32, ow: u32; };
+  struct Size { n: u32, c: u32, h: u32, w: u32, oh: u32, ow: u32, };
   @group(0) @binding(2) var<uniform> size: Size;
 
   @compute @workgroup_size(8, 8, 1)
@@ -84,11 +84,11 @@ OIDN_NAMESPACE_BEGIN
   )wgsl";
 
   static const char* kUpsampleWGSL = R"wgsl(
-  struct Tensor { data: array<f32>; };
+  struct Tensor { data: array<f32>, };
 
   @group(0) @binding(0) var<storage, read>  src : Tensor;
   @group(0) @binding(1) var<storage, read_write> dst : Tensor;
-  struct Size { n: u32, c: u32, h: u32, w: u32; };
+  struct Size { n: u32, c: u32, h: u32, w: u32, };
   @group(0) @binding(2) var<uniform> size: Size;
 
   @compute @workgroup_size(8, 8, 1)
@@ -356,7 +356,7 @@ OIDN_NAMESPACE_BEGIN
       return;
 
     static const char* kWGSL = R"wgsl(
-    struct Tensor { data: array<f32>; };
+    struct Tensor { data: array<f32>, };
     @group(0) @binding(0) var<storage, read>  A: Tensor;
     @group(0) @binding(1) var<storage, read>  B: Tensor;
     @group(0) @binding(2) var<storage, read_write> C: Tensor;
@@ -414,7 +414,7 @@ OIDN_NAMESPACE_BEGIN
       return;
 
     static const char* kWGSL = R"wgsl(
-    struct Tensor { data: array<f32>; };
+    struct Tensor { data: array<f32>, };
     @group(0) @binding(0) var<storage, read>  A: Tensor;
     @group(0) @binding(1) var<storage, read>  B: Tensor;
     @group(0) @binding(2) var<storage, read_write> C: Tensor;
@@ -472,7 +472,7 @@ OIDN_NAMESPACE_BEGIN
       return;
 
     static const char* kWGSL = R"wgsl(
-    struct Tensor { data: array<f32>; };
+    struct Tensor { data: array<f32>, };
     @group(0) @binding(0) var<storage, read>  A: Tensor;
     @group(0) @binding(1) var<storage, read_write> B: Tensor;
     @group(0) @binding(2) var<uniform> size: u32;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,14 @@
 find_package(GTest REQUIRED)
 
 function(add_webgpu_test exe test_name source)
-  add_executable(${exe} ${source})
+  add_executable(${exe} ${source} test_main.cpp)
   target_include_directories(${exe} PRIVATE ${PROJECT_SOURCE_DIR}/devices/webgpu)
   target_include_directories(${exe} PRIVATE ${PROJECT_SOURCE_DIR}/devices/cpu)
   target_include_directories(${exe} PRIVATE ${PROJECT_SOURCE_DIR})
   target_include_directories(${exe} PRIVATE ${OIDN_WGPU_DIR}/include)
-  target_link_libraries(${exe} PRIVATE OpenImageDenoise OpenImageDenoise_core OpenImageDenoise_device_cpu OpenImageDenoise_device_webgpu GTest::GTest GTest::Main)
+  target_link_libraries(${exe} PRIVATE OpenImageDenoise OpenImageDenoise_core OpenImageDenoise_device_cpu OpenImageDenoise_device_webgpu GTest::GTest)
   add_test(NAME ${test_name} COMMAND ${exe})
+  set_property(TEST ${test_name} PROPERTY SKIP_RETURN_CODE 77)
 endfunction()
 
 add_webgpu_test(webgpu_conv_test WebGPU.Conv2d test_webgpu_conv.cpp)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+class SkipListener : public ::testing::EmptyTestEventListener {
+public:
+  void OnTestPartResult(const ::testing::TestPartResult& result) override {
+    if (result.type() == ::testing::TestPartResult::kSkip)
+      skipped = true;
+  }
+  static bool skipped;
+};
+
+bool SkipListener::skipped = false;
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::UnitTest::GetInstance()->listeners().Append(new SkipListener);
+  int ret = RUN_ALL_TESTS();
+  if (ret == 0 && SkipListener::skipped)
+    return 77; // special code for skipped
+  return ret;
+}


### PR DESCRIPTION
## Summary
- improve WGSL shaders for WebGPU backend
- ensure skipped Google tests return code 77
- add helper main for tests
- update developer notes about skip handling

## Testing
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build --output-on-failure -R WebGPU.Upsample`

------
https://chatgpt.com/codex/tasks/task_e_68488189dd8c832a97e8da012ec3a9c2