### PR TITLE
Add WebGPU arena test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,9 @@ Source tree:
   ├─ webgpu_pool.h / .cpp        # Pool op wrapper
   ├─ webgpu_upsample.h / .cpp    # Upsample op wrapper
   ├─ webgpu_tensor.h             # POD for tensor views
+  ├─ webgpu_buffer.h / .cpp      # device buffer implementation
+  ├─ webgpu_heap.h / .cpp        # heap backing arenas
+  ├─ webgpu_arena.h / .cpp       # simple allocator built on WebGPUHeap
   └─ CMakeLists.txt              # adds option OIDN_DEVICE_WEBGPU
 
 ### Implementation details
@@ -76,6 +79,8 @@ Fixed stride = 1, no padding, arbitrary N,C,H,W.
 Work-group size hard-coded to 8×8×1.
 Host ↔ GPU transfers use the public buffer API (`oidnNewBuffer`, `oidnWriteBuffer`,
 `oidnReadBuffer`).
+Memory is managed through `WebGPUArena` / `WebGPUHeap`, which allow sub-allocating
+multiple buffers from a single WebGPU buffer.
 Currently kernels for `conv2d_eltwise`, `pool2x2`, `upsample2x`, `add`, `mul`, `softplus`, `input_process`, `output_process`, `image_copy`, and `autoexposure` are implemented in WGSL shaders.
 Earlier revisions executed the last four operations on the CPU, but they now run on the GPU as well.
 Op classes map these kernels through the standard Engine API and are validated against the CPU backend.
@@ -93,6 +98,8 @@ Hardware Vulkan/Metal or Lavapipe SW fallback.
 Run: ctest --output-on-failure -R WebGPU
 Skipped tests return exit code 77 which CTest recognizes as SKIP.
 
+`WebGPU.Arena` exercises the buffer heap allocator.
+
 The tests internally:
 
 * prepare deterministic random tensors,
@@ -106,7 +113,7 @@ They pass if
 
 Priority	Task	Brief Description
 P0      Element-wise kernels    **Done** – WGSL implementations of add, mul, and softplus are available.
-P1	Memory allocator	Replace the “one buffer per tensor” strategy with a sub-allocator to reduce memory & improve performance.
+P1      Memory allocator        **Done** – buffers share memory through WebGPUArena/WebGPUHeap.
 P1	Graph execution	Record multiple layers in a single command buffer to amortise overhead.
 P2	Full denoiser demo	Make examples/denoise run on a 256×256 tile using the WebGPU backend.
 P2	Performance passes	Explore workgroup sizes, shared-memory tiling, fused convolution blocks.

--- a/devices/webgpu/webgpu_engine.cpp
+++ b/devices/webgpu/webgpu_engine.cpp
@@ -577,11 +577,11 @@ OIDN_NAMESPACE_BEGIN
                                               &size);
 
     WGPUBindGroupEntry entries[5] = {};
-    entries[0].binding = 0; entries[0].buffer = src.buf; entries[0].size = src.n*src.c*src.h*src.w*sizeof(float);
-    entries[1].binding = 1; entries[1].buffer = weight.buf; entries[1].size = weight.n*weight.c*weight.h*weight.w*sizeof(float);
-    entries[2].binding = 2; entries[2].buffer = bias.buf; entries[2].size = bias.n*bias.c*bias.h*bias.w*sizeof(float);
-    entries[3].binding = 3; entries[3].buffer = dst.buf; entries[3].size = dst.n*dst.c*oh*ow*sizeof(float);
-    entries[4].binding = 4; entries[4].buffer = sizeBuf; entries[4].size = sizeof(Size);
+    entries[0].binding = 0; entries[0].buffer = src.buf; entries[0].offset = src.offset; entries[0].size = src.n*src.c*src.h*src.w*sizeof(float);
+    entries[1].binding = 1; entries[1].buffer = weight.buf; entries[1].offset = weight.offset; entries[1].size = weight.n*weight.c*weight.h*weight.w*sizeof(float);
+    entries[2].binding = 2; entries[2].buffer = bias.buf; entries[2].offset = bias.offset; entries[2].size = bias.n*bias.c*bias.h*bias.w*sizeof(float);
+    entries[3].binding = 3; entries[3].buffer = dst.buf; entries[3].offset = dst.offset; entries[3].size = dst.n*dst.c*oh*ow*sizeof(float);
+    entries[4].binding = 4; entries[4].buffer = sizeBuf; entries[4].offset = 0; entries[4].size = sizeof(Size);
     WGPUBindGroupDescriptor bgDesc{};
     bgDesc.layout = bindGroupLayout;
     bgDesc.entryCount = 5;
@@ -601,7 +601,7 @@ OIDN_NAMESPACE_BEGIN
       size_t outBytes = dst.n*dst.c*oh*ow*sizeof(float);
       WGPUBuffer readback = device->createBuffer(outBytes,
                           WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst);
-      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, 0, readback, 0, outBytes);
+      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, dst.offset, readback, 0, outBytes);
       readbacks.push_back({dst.buf, readback, outputHosts[dst.buf], outBytes});
     }
 
@@ -630,9 +630,9 @@ OIDN_NAMESPACE_BEGIN
                               &size);
 
     WGPUBindGroupEntry entries[3] = {};
-    entries[0].binding = 0; entries[0].buffer = src.buf; entries[0].size = src.n*src.c*src.h*src.w*sizeof(float);
-    entries[1].binding = 1; entries[1].buffer = dst.buf; entries[1].size = dst.n*dst.c*oh*ow*sizeof(float);
-    entries[2].binding = 2; entries[2].buffer = sizeBuf; entries[2].size = sizeof(Size);
+    entries[0].binding = 0; entries[0].buffer = src.buf; entries[0].offset = src.offset; entries[0].size = src.n*src.c*src.h*src.w*sizeof(float);
+    entries[1].binding = 1; entries[1].buffer = dst.buf; entries[1].offset = dst.offset; entries[1].size = dst.n*dst.c*oh*ow*sizeof(float);
+    entries[2].binding = 2; entries[2].buffer = sizeBuf; entries[2].offset = 0; entries[2].size = sizeof(Size);
 
     WGPUBindGroupDescriptor bgDesc{};
     bgDesc.layout = upsampleBindGroupLayout;
@@ -653,7 +653,7 @@ OIDN_NAMESPACE_BEGIN
       size_t outBytes = dst.n*dst.c*oh*ow*sizeof(float);
       WGPUBuffer readback = device->createBuffer(outBytes,
                           WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst);
-      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, 0, readback, 0, outBytes);
+      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, dst.offset, readback, 0, outBytes);
       readbacks.push_back({dst.buf, readback, outputHosts[dst.buf], outBytes});
     }
 
@@ -705,7 +705,7 @@ OIDN_NAMESPACE_BEGIN
       size_t outBytes = dst.n*dst.c*oh*ow*sizeof(float);
       WGPUBuffer readback = device->createBuffer(outBytes,
                           WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst);
-      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, 0, readback, 0, outBytes);
+      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, dst.offset, readback, 0, outBytes);
       readbacks.push_back({dst.buf, readback, outputHosts[dst.buf], outBytes});
     }
 
@@ -752,17 +752,17 @@ OIDN_NAMESPACE_BEGIN
                               WGPUBufferUsage_Uniform | WGPUBufferUsage_CopyDst,
                               &size);
     WGPUBindGroupEntry entries[4] = {};
-    entries[0].binding = 0; entries[0].buffer = A.buf; entries[0].size = size*sizeof(float);
-    entries[1].binding = 1; entries[1].buffer = B.buf; entries[1].size = size*sizeof(float);
-    entries[2].binding = 2; entries[2].buffer = dst.buf; entries[2].size = size*sizeof(float);
-    entries[3].binding = 3; entries[3].buffer = sizeBuf; entries[3].size = sizeof(uint32_t);
+    entries[0].binding = 0; entries[0].buffer = A.buf; entries[0].offset = A.offset; entries[0].size = size*sizeof(float);
+    entries[1].binding = 1; entries[1].buffer = B.buf; entries[1].offset = B.offset; entries[1].size = size*sizeof(float);
+    entries[2].binding = 2; entries[2].buffer = dst.buf; entries[2].offset = dst.offset; entries[2].size = size*sizeof(float);
+    entries[3].binding = 3; entries[3].buffer = sizeBuf; entries[3].offset = 0; entries[3].size = sizeof(uint32_t);
     dispatch1D(device, addPipeline, addBindGroupLayout, entries, 4, size);
     if (dst.type == WebGPUTensorType::OUTPUT)
     {
       WGPUBuffer readback = device->createBuffer(size*sizeof(float),
                           WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst);
       WGPUCommandEncoder enc = wgpuDeviceCreateCommandEncoder(device->device, nullptr);
-      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, 0, readback, 0, size*sizeof(float));
+      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, dst.offset, readback, 0, size*sizeof(float));
       WGPUCommandBuffer cmd = wgpuCommandEncoderFinish(enc, nullptr);
       device->submit(cmd);
       wgpuCommandBufferRelease(cmd);
@@ -782,17 +782,17 @@ OIDN_NAMESPACE_BEGIN
                               WGPUBufferUsage_Uniform | WGPUBufferUsage_CopyDst,
                               &size);
     WGPUBindGroupEntry entries[4] = {};
-    entries[0].binding = 0; entries[0].buffer = A.buf; entries[0].size = size*sizeof(float);
-    entries[1].binding = 1; entries[1].buffer = B.buf; entries[1].size = size*sizeof(float);
-    entries[2].binding = 2; entries[2].buffer = dst.buf; entries[2].size = size*sizeof(float);
-    entries[3].binding = 3; entries[3].buffer = sizeBuf; entries[3].size = sizeof(uint32_t);
+    entries[0].binding = 0; entries[0].buffer = A.buf; entries[0].offset = A.offset; entries[0].size = size*sizeof(float);
+    entries[1].binding = 1; entries[1].buffer = B.buf; entries[1].offset = B.offset; entries[1].size = size*sizeof(float);
+    entries[2].binding = 2; entries[2].buffer = dst.buf; entries[2].offset = dst.offset; entries[2].size = size*sizeof(float);
+    entries[3].binding = 3; entries[3].buffer = sizeBuf; entries[3].offset = 0; entries[3].size = sizeof(uint32_t);
     dispatch1D(device, mulPipeline, mulBindGroupLayout, entries, 4, size);
     if (dst.type == WebGPUTensorType::OUTPUT)
     {
       WGPUBuffer readback = device->createBuffer(size*sizeof(float),
                           WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst);
       WGPUCommandEncoder enc = wgpuDeviceCreateCommandEncoder(device->device, nullptr);
-      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, 0, readback, 0, size*sizeof(float));
+      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, dst.offset, readback, 0, size*sizeof(float));
       WGPUCommandBuffer cmd = wgpuCommandEncoderFinish(enc, nullptr);
       device->submit(cmd);
       wgpuCommandBufferRelease(cmd);
@@ -811,16 +811,16 @@ OIDN_NAMESPACE_BEGIN
                               WGPUBufferUsage_Uniform | WGPUBufferUsage_CopyDst,
                               &size);
     WGPUBindGroupEntry entries[3] = {};
-    entries[0].binding = 0; entries[0].buffer = src.buf; entries[0].size = size*sizeof(float);
-    entries[1].binding = 1; entries[1].buffer = dst.buf; entries[1].size = size*sizeof(float);
-    entries[2].binding = 2; entries[2].buffer = sizeBuf; entries[2].size = sizeof(uint32_t);
+    entries[0].binding = 0; entries[0].buffer = src.buf; entries[0].offset = src.offset; entries[0].size = size*sizeof(float);
+    entries[1].binding = 1; entries[1].buffer = dst.buf; entries[1].offset = dst.offset; entries[1].size = size*sizeof(float);
+    entries[2].binding = 2; entries[2].buffer = sizeBuf; entries[2].offset = 0; entries[2].size = sizeof(uint32_t);
     dispatch1D(device, softplusPipeline, softplusBindGroupLayout, entries, 3, size);
     if (dst.type == WebGPUTensorType::OUTPUT)
     {
       WGPUBuffer readback = device->createBuffer(size*sizeof(float),
                           WGPUBufferUsage_MapRead | WGPUBufferUsage_CopyDst);
       WGPUCommandEncoder enc = wgpuDeviceCreateCommandEncoder(device->device, nullptr);
-      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, 0, readback, 0, size*sizeof(float));
+      wgpuCommandEncoderCopyBufferToBuffer(enc, dst.buf, dst.offset, readback, 0, size*sizeof(float));
       WGPUCommandBuffer cmd = wgpuCommandEncoderFinish(enc, nullptr);
       device->submit(cmd);
       wgpuCommandBufferRelease(cmd);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,3 +19,4 @@ add_webgpu_test(webgpu_output_process_test WebGPU.OutputProcess test_webgpu_outp
 add_webgpu_test(webgpu_image_copy_test WebGPU.ImageCopy test_webgpu_image_copy.cpp)
 add_webgpu_test(webgpu_autoexposure_test WebGPU.Autoexposure test_webgpu_autoexposure.cpp)
 add_webgpu_test(webgpu_eltwise_test WebGPU.Eltwise test_webgpu_eltwise.cpp)
+add_webgpu_test(webgpu_arena_test WebGPU.Arena test_webgpu_arena.cpp)

--- a/tests/test_webgpu_arena.cpp
+++ b/tests/test_webgpu_arena.cpp
@@ -1,0 +1,62 @@
+#include "OpenImageDenoise/oidn.hpp"
+#include "OpenImageDenoise/webgpu.h"
+#include "../devices/webgpu/webgpu_arena.h"
+#include "../devices/webgpu/webgpu_buffer.h"
+#include "../devices/webgpu/webgpu_engine.h"
+#include "../common/platform.h"
+#include <gtest/gtest.h>
+
+using namespace oidn;
+
+static void fillRandom(float* data, size_t count)
+{
+  for(size_t i=0;i<count;++i)
+    data[i] = float(i%7)*0.2f + 1.0f;
+}
+
+TEST(WebGPU, Arena)
+{
+  if (!isWebGPUDeviceSupported())
+    GTEST_SKIP();
+
+  auto dev = newWebGPUDevice();
+  dev.commit();
+  WebGPUEngine* eng = getEngine(dev);
+
+  constexpr size_t COUNT = 64;
+  float a[COUNT];
+  float b[COUNT];
+  fillRandom(a, COUNT);
+  fillRandom(b, COUNT);
+  float ref[COUNT];
+  for(size_t i=0;i<COUNT;++i)
+    ref[i] = a[i] + b[i];
+
+  const size_t bufSize = sizeof(a);
+  const size_t heapSize = bufSize*2;
+  auto arena = makeRef<WebGPUArena>(eng, heapSize);
+
+  auto bufA = arena->newBuffer(bufSize, 0);
+  auto bufB = arena->newBuffer(bufSize, bufSize);
+  auto bufOutRef = dev.newBuffer(bufSize);
+
+  bufA->write(0, bufSize, a);
+  bufB->write(0, bufSize, b);
+
+  WebGPUBuffer* wA = static_cast<WebGPUBuffer*>(bufA.get());
+  WebGPUBuffer* wB = static_cast<WebGPUBuffer*>(bufB.get());
+  WebGPUBuffer* wOut = static_cast<WebGPUBuffer*>(reinterpret_cast<Buffer*>(bufOutRef.getHandle()));
+
+  WebGPUTensor tA{wA->getWGPUBuffer(), 0, 1,1,1,COUNT, WebGPUTensorType::INPUT};
+  WebGPUTensor tB{wB->getWGPUBuffer(), bufSize, 1,1,1,COUNT, WebGPUTensorType::INPUT};
+  WebGPUTensor tOut{wOut->getWGPUBuffer(), 0, 1,1,1,COUNT, WebGPUTensorType::INPUT};
+
+  eng->add(tA,tB,tOut);
+  dev.sync();
+
+  float out[COUNT];
+  bufOutRef.read(0, bufSize, out);
+  for(size_t i=0;i<COUNT;++i)
+    ASSERT_NEAR(out[i], ref[i], 1e-6f);
+}
+


### PR DESCRIPTION
## Summary
- extend WebGPU engine to honor tensor buffer offsets
- document allocator state in AGENTS notes
- create `WebGPU.Arena` unit test exercising the heap allocator

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DOIDN_DEVICE_WEBGPU=ON -DOIDN_FILTER_RT=OFF -DOIDN_FILTER_RTLIGHTMAP=OFF .`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure -R WebGPU.Arena`

------
https://chatgpt.com/codex/tasks/task_e_6849340e58d4832a8792713c1eef1c47