### PR TITLE
Enable Autoexposure test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,8 +109,9 @@ Hardware Vulkan/Metal or Lavapipe SW fallback.
 Run: ctest --output-on-failure -R WebGPU
 Skipped tests return exit code 77 which CTest recognizes as SKIP.
 
-The `WebGPU.Autoexposure` and `WebGPU.Eltwise` unit tests are currently
-skipped due to unresolved backend issues.
+`WebGPU.Autoexposure` now runs successfully after fixing a lifetime issue
+with the CPU reference buffer.  Only `WebGPU.Eltwise` remains skipped due
+to unresolved backend issues.
 
 `WebGPU.Arena` exercises the buffer heap allocator.
 

--- a/tests/test_webgpu_autoexposure.cpp
+++ b/tests/test_webgpu_autoexposure.cpp
@@ -14,7 +14,6 @@ TEST(WebGPU, Autoexposure)
 {
   if (!isWebGPUDeviceSupported())
     GTEST_SKIP();
-  GTEST_SKIP(); // Temporarily skip due to backend issues
 
   auto dev = newWebGPUDevice();
   dev.commit();
@@ -23,8 +22,8 @@ TEST(WebGPU, Autoexposure)
   const uint32_t H=2, W=2;
   float color[H*W*3] = {0.1f,0.2f,0.3f, 0.4f,0.5f,0.6f, 0.7f,0.8f,0.9f, 0.3f,0.2f,0.1f};
   float refVal = 1.f;
-  Ref<Buffer> hostBuf;
   DeviceRef cpuDev;
+  Ref<Buffer> hostBuf;
   CPUEngine* cpuEng = nullptr;
 
   if (isCPUDeviceSupported())


### PR DESCRIPTION
## Summary
- fix lifetime bug in test_webgpu_autoexposure
- enable the WebGPU.Autoexposure test
- document that Autoexposure passes in AGENTS.md

## Testing
- `ctest --test-dir build --output-on-failure -R WebGPU.Autoexposure`
- `ctest --test-dir build --output-on-failure -R WebGPU`

------
https://chatgpt.com/codex/tasks/task_e_68496caf0080832a864cdf9a0cab5705