### PR TITLE
Rename WebGPU tensor helper

### DIFF
--- a/devices/webgpu/webgpu_engine.cpp
+++ b/devices/webgpu/webgpu_engine.cpp
@@ -523,8 +523,8 @@ OIDN_NAMESPACE_BEGIN
     softplusPipeline = wgpuDeviceCreateComputePipeline(device->device, &cpDesc);
   }
 
-  WebGPUTensor WebGPUEngine::newTensor(const float* data, WebGPUTensorType type,
-                                       uint32_t n, uint32_t c, uint32_t h, uint32_t w)
+  WebGPUTensor WebGPUEngine::makeTensor(const float* data, WebGPUTensorType type,
+                                        uint32_t n, uint32_t c, uint32_t h, uint32_t w)
   {
     size_t count = size_t(n) * c * h * w;
     size_t bytes = count * sizeof(float);
@@ -541,8 +541,8 @@ OIDN_NAMESPACE_BEGIN
     return {buf,0,n,c,h,w,type};
   }
 
-  WebGPUTensor WebGPUEngine::newTensor(const BufferRef& buffer, WebGPUTensorType type,
-                                       uint32_t n, uint32_t c, uint32_t h, uint32_t w)
+  WebGPUTensor WebGPUEngine::makeTensor(const BufferRef& buffer, WebGPUTensorType type,
+                                        uint32_t n, uint32_t c, uint32_t h, uint32_t w)
   {
     Buffer* bufObj = reinterpret_cast<Buffer*>(buffer.getHandle());
     WebGPUBuffer* wb = dynamic_cast<WebGPUBuffer*>(bufObj);

--- a/devices/webgpu/webgpu_engine.h
+++ b/devices/webgpu/webgpu_engine.h
@@ -38,10 +38,12 @@ OIDN_NAMESPACE_BEGIN
                         const Ref<CancellationToken>& ct = nullptr) override;
     void wait() override;
 
-    WebGPUTensor newTensor(const float* data, WebGPUTensorType type,
-                           uint32_t n, uint32_t c, uint32_t h, uint32_t w);
-    WebGPUTensor newTensor(const BufferRef& buffer, WebGPUTensorType type,
-                           uint32_t n, uint32_t c, uint32_t h, uint32_t w);
+    // Convenience helpers for creating lightweight tensor views used by the
+    // custom WebGPU kernels. These are not overrides of Engine::newTensor().
+    WebGPUTensor makeTensor(const float* data, WebGPUTensorType type,
+                            uint32_t n, uint32_t c, uint32_t h, uint32_t w);
+    WebGPUTensor makeTensor(const BufferRef& buffer, WebGPUTensorType type,
+                            uint32_t n, uint32_t c, uint32_t h, uint32_t w);
 
     void conv2d_eltwise(const WebGPUTensor& src,
                         const WebGPUTensor& weight,

--- a/tests/test_webgpu_eltwise.cpp
+++ b/tests/test_webgpu_eltwise.cpp
@@ -42,9 +42,9 @@ TEST(WebGPU, EltwiseAdd)
   bufA.write(0,sizeof(a),a);
   bufB.write(0,sizeof(b),b);
 
-  auto tA = eng->newTensor(BufferRef(bufA.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
-  auto tB = eng->newTensor(BufferRef(bufB.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
-  auto tOut= eng->newTensor(BufferRef(bufOut.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tA = eng->makeTensor(BufferRef(bufA.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tB = eng->makeTensor(BufferRef(bufB.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tOut= eng->makeTensor(BufferRef(bufOut.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
 
   eng->add(tA,tB,tOut);
   dev.sync();
@@ -76,9 +76,9 @@ TEST(WebGPU, EltwiseMul)
   auto bufA=dev.newBuffer(sizeof(a)); bufA.write(0,sizeof(a),a);
   auto bufB=dev.newBuffer(sizeof(b)); bufB.write(0,sizeof(b),b);
   auto bufOut=dev.newBuffer(sizeof(ref));
-  auto tA = eng->newTensor(BufferRef(bufA.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
-  auto tB = eng->newTensor(BufferRef(bufB.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
-  auto tOut= eng->newTensor(BufferRef(bufOut.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tA = eng->makeTensor(BufferRef(bufA.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tB = eng->makeTensor(BufferRef(bufB.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tOut= eng->makeTensor(BufferRef(bufOut.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
 
   eng->mul(tA,tB,tOut);
   dev.sync();
@@ -107,8 +107,8 @@ TEST(WebGPU, EltwiseSoftplus)
 
   auto bufA=dev.newBuffer(sizeof(a)); bufA.write(0,sizeof(a),a);
   auto bufOut=dev.newBuffer(sizeof(ref));
-  auto tA = eng->newTensor(BufferRef(bufA.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
-  auto tOut= eng->newTensor(BufferRef(bufOut.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tA = eng->makeTensor(BufferRef(bufA.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
+  auto tOut= eng->makeTensor(BufferRef(bufOut.getHandle()), WebGPUTensorType::INPUT, 1,1,1,W);
 
   eng->softplus(tA,tOut);
   dev.sync();


### PR DESCRIPTION
## Summary
- avoid confusion with Engine::newTensor by renaming the WebGPU-specific helper to `makeTensor`
- update element-wise test accordingly

## Testing
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DOIDN_DEVICE_WEBGPU=ON -DOIDN_FILTER_RT=OFF -DOIDN_FILTER_RTLIGHTMAP=OFF .`
- `cmake --build build -j$(nproc)`
- `ctest --output-on-failure -R WebGPU`

------
https://chatgpt.com/codex/tasks/task_e_6849b7c86b68832a82a6d4577a61ba21